### PR TITLE
upgrade artifactory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM lolhens/baseimage-oracle-jdk:latest
 MAINTAINER LolHens <pierrekisters@gmail.com>
 
 
-ENV ARTIFACTORY_VERSION 4.12.0
+ENV ARTIFACTORY_VERSION 4.12.0.1
 ENV ARTIFACTORY_NAME artifactory-oss-$ARTIFACTORY_VERSION
 ENV ARTIFACTORY_FILE jfrog-$ARTIFACTORY_NAME.zip
 ENV ARTIFACTORY_URL https://bintray.com/artifact/download/jfrog/artifactory/$ARTIFACTORY_FILE


### PR DESCRIPTION
- fix last upgrade that specified 4.12.0,
  which was a mistake. This commit specifies
  latest version.
